### PR TITLE
V4 renamed fcc_id to id

### DIFF
--- a/src/Response/FCC/AddRecords.php
+++ b/src/Response/FCC/AddRecords.php
@@ -31,9 +31,11 @@ class AddRecords
             Assert::isArray($response['records_id']);
             $mappings = [];
             foreach ($response['records_id'] as $mapping) {
-                Assert::keyExists($mapping, 'fcc_id');
+                if (!isset($mapping['fcc_id']) && !isset($mapping['id'])) {
+                    throw new \InvalidArgumentException('Expected the key "fcc_id" or "id" to exist.');
+                }
                 Assert::keyExists($mapping, 'external_id');
-                $mappings[] = new IdMapping($mapping['fcc_id'], $mapping['external_id']);
+                $mappings[] = new IdMapping($mapping['fcc_id'] ?? $mapping['id'], $mapping['external_id']);
             }
 
             return new self($mappings);

--- a/tests/Unit/Response/FCC/AddRecordsTest.php
+++ b/tests/Unit/Response/FCC/AddRecordsTest.php
@@ -37,6 +37,29 @@ class AddRecordsTest extends TestCase
     /**
      * @test
      */
+    public function correctResponseForV4(): void
+    {
+        $response = AddRecords::fromArray(
+            [
+                'records_id' => [
+                    ['id' => 1, 'external_id' => 'A'],
+                    ['id' => 2, 'external_id' => 'B'],
+                ],
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                new IdMapping(1, 'A'),
+                new IdMapping(2, 'B'),
+            ],
+            $response->getRecordsId()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function noRecordsId(): void
     {
         $this->expectException(MalformedResponse::class);
@@ -72,5 +95,15 @@ class AddRecordsTest extends TestCase
         $this->expectException(MalformedResponse::class);
 
         AddRecords::fromArray(['records_id' => ['fcc_id' => 1]]);
+    }
+
+    /**
+     * @test
+     */
+    public function noExternalIdForV4(): void
+    {
+        $this->expectException(MalformedResponse::class);
+
+        AddRecords::fromArray(['records_id' => ['id' => 1]]);
     }
 }


### PR DESCRIPTION
Now the API is returning

```
"records_id" => [
      [
        "id" => 6368094,
        "ext_id" => "LCL_ANS_1",
        "external_id" => "LCL_ANS_1"
      ]
    ]
```

With this PR both v1 and v4 (probably including v2 and v3) versions of response are supported